### PR TITLE
Fix up Readme and typo in stats-voc.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Make sure that the main folder of the toolkit is in your `PATH` variable: `expor
 
 Steps to decode voice:
  - Decode your captured and demodulated bits using `iridium-parser` and put the result into a file: `pypy iridium-parser.py output.bits > output.parsed`
- - Use `voc-stats.py` to see streams of captured voice frames: `./voc-stats.py  output.parsed`
- - Click once left and once right to select an area. `voc-stats.py` will try do decode and play the selected samples using the `play-iridium-ambe` script.
+ - Use `stats-voc.py` to see streams of captured voice frames: `./stats-voc.py output.parsed`
+ - Click once left and once right to select an area. `stats-voc.py` will try do decode and play the selected samples using the `play-iridium-ambe` script.
 
 
 ### Main Components

--- a/stats-voc.py
+++ b/stats-voc.py
@@ -83,7 +83,7 @@ def main():
 
     cid = fig.canvas.mpl_connect('button_press_event', onclick)
 
-    plt.title("Click once left and once rigth to define an aerea. The script will try to play iridium using the play-iridium-ambe shell script.")
+    plt.title("Click once left and once rigth to define an area. The script will try to play iridium using the play-iridium-ambe shell script.")
     plt.show()
 
 


### PR DESCRIPTION
Readme has references to "voc-stats.py", which doesn't exist, and contains the exact functionality of "stats-voc.py"  

The script itself has a typo of "aerea", which has been corrected to "area"