### PR TITLE
Detect/pay sounds via mplayer or aplay

### DIFF
--- a/play-iridium-ambe
+++ b/play-iridium-ambe
@@ -2,4 +2,9 @@
 bits_to_dfs.py $1 /tmp/voice.dfs
 #ambe -w /tmp/voice.dfs
 ir77_ambe_decode /tmp/voice.dfs /tmp/voice.wav
-mplayer /tmp/voice.wav
+
+if hash mplayer 2>/dev/null; then
+  mplayer /tmp/voice.wav
+else
+  aplay /tmp/voice.wav
+fi


### PR DESCRIPTION
On Fedroa aplay (ALSA play) is installed by default but not mplayer. This just makes one less setup dependency to install.