### PR TITLE
skip ERR lines in stats.py, handle zero signal in reassembler.py

### DIFF
--- a/reassembler.py
+++ b/reassembler.py
@@ -224,7 +224,10 @@ class ReassembleIDALAP(ReassembleIDA):
         if len(data)==1:
             return
         lapdm=data
-        olvl=10*math.log(level,10)
+        try:
+            olvl=10*math.log(level,10)
+        except:
+            olvl=0
         if olvl>127:
             olvl=127
         if olvl<-126:

--- a/reassembler.py
+++ b/reassembler.py
@@ -101,7 +101,11 @@ class ReassembleIDA(Reassemble):
     def __init__(self):
         pass
     def filter(self,line):
-        q=super(ReassembleIDA,self).filter(line)
+	try:
+        	q=super(ReassembleIDA,self).filter(line)
+	except:
+		q=MyObject()
+		q.typ="NOTIDA:"
         if q.typ=="IDA:":
             qqq=re.compile('.* CRC:OK')
             if not qqq.match(q.data):

--- a/stats.py
+++ b/stats.py
@@ -44,6 +44,8 @@ frames['VDA'] = [colors[2], 'o', [], []]
 for line in f:
     line = line.strip().split()
     type = line[0][:-1]
+    if type == "ERR":
+        continue
     #ts_base = int(line[1].split('-')[1].split('.')[0])
     ts_base = 0
     ts = ts_base + float(line[2])/1000.


### PR DESCRIPTION
if the signal level is zero, reassembler will try and do math.log(level,10) and get a value it isnt expecting. There's probably a more pythonic fix than mine, but it does the job. 

Also stats.py can't handle the output of iridium-parser.py if the output includes errors as `ts = ts_base + float(line[2])/1000` fails due to line[2] containing the strings "Couldn't"