### PR TITLE
Get rid of the colon after each frame type in stats-parsed

### DIFF
--- a/stats-parsed
+++ b/stats-parsed
@@ -2,7 +2,7 @@
 echo ----------------------------------------------
 echo "$1: " `wc -l $1 | cut -f1 -d ' '` "lines"
 echo "Good frames:"
-cat $1 | grep -v ERR | cut -f1 -d ' '| sort | uniq -c
+cat $1 | grep -v ERR | cut -f1 -d ' '| sort | uniq -c | sed 's/://'
 echo "Total good frames:" `cat $1 | grep -v ERR | wc -l`
 echo "IDA with CRC:OK:" `cat $1 | grep CRC:OK | wc -l`
 echo "IIP with FCS:OK:" `cat $1 | grep FCS:OK | wc -l`


### PR DESCRIPTION
Cosmetic change.

Before:
```
----------------------------------------------
parsed:  60 lines
Good frames:
      8 IDA:
     40 ISY:
Total good frames: 60
IDA with CRC:OK: 1
IIP with FCS:OK: 1
Bad frames:
Total bad frames: 0
----------------------------------------------
```

After:
```
----------------------------------------------
parsed:  60 lines
Good frames:
      8 IDA
     40 ISY
Total good frames: 60
IDA with CRC:OK: 1
IIP with FCS:OK: 1
Bad frames:
Total bad frames: 0
----------------------------------------------
```
