### PR TITLE
ACARS JSON to airframes.io 

### DIFF
--- a/html/example.sh
+++ b/html/example.sh
@@ -21,6 +21,6 @@ echo ""
 echo "and make sure 'iridium-parser' is running with -o zmq on this host"
 echo
 
-python -m http.server --bind 127.0.0.1 8888
+python3 -m http.server --bind 127.0.0.1 8888
 
 kill $reass

--- a/iridium-acars-to-airframes.py
+++ b/iridium-acars-to-airframes.py
@@ -14,7 +14,7 @@
 # EXAMPLE:
 #
 #  $ export PYTHONUNBUFFERED=x
-#  $ reassembler.py -i zmq: -m acars -a json --station YOUR_STATION_IDENT | acars-to-airframes.py
+#  $ reassembler.py -i zmq: -m acars -a json --station YOUR_STATION_IDENT | iridium-acars-to-airframes.py
 #
 # USAGE:
 #

--- a/iridium-acars-to-airframes.py
+++ b/iridium-acars-to-airframes.py
@@ -2,7 +2,7 @@
 #
 # iridium-acars-to-airframes.py
 #
-# Send the ACARS JSON output from iridium-toolkit to Airframes.io. You may send to additional TCP destinations
+# Send the ACARS JSON output from iridium-toolkit to Airframes.io. You may send to additional destinations
 # by specifying the --output option multiple times.
 #
 # INSTRUCTIONS:
@@ -28,7 +28,7 @@
 #                           Override station ident
 #     --debug, -d           Enable debug output
 #     --output OUTPUT, -o OUTPUT
-#                           Send output via TCP to additional destination transport:host:port (where transport is "tcp" or "udp")
+#                           Send output to additional destination transport:host:port (where transport is "tcp" or "udp")
 #
 # For more information about Airframes, see https://app.airframes.io/about or contact kevin@airframes.io.
 #

--- a/iridium-acars-to-airframes.py
+++ b/iridium-acars-to-airframes.py
@@ -2,8 +2,8 @@
 #
 # iridium-acars-to-airframes.py
 #
-# Send the ACARS JSON output from iridium-toolkit to Airframes.io. You may send to additional outputs by
-# specifying the --output option multiple times.
+# Send the ACARS JSON output from iridium-toolkit to Airframes.io. You may send to additional TCP destinations
+# by specifying the --output option multiple times.
 #
 # INSTRUCTIONS:
 #
@@ -28,7 +28,7 @@
 #                           Override station ident
 #     --debug, -d           Enable debug output
 #     --output OUTPUT, -o OUTPUT
-#                           Send output via TCP to additional destination host:port
+#                           Send output via TCP to additional destination transport:host:port (where transport is "tcp" or "udp")
 #
 # For more information about Airframes, see https://app.airframes.io/about or contact kevin@airframes.io.
 #
@@ -46,13 +46,6 @@ debug = True
 sock = None
 sockets = {}
 
-def connect():
-  s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-  s.connect((ingest_host, ingest_port))
-  if debug:
-    print("Connected to Airframes Iridium ACARS ingest (%s:%d)" % (ingest_host, ingest_port))
-  return s
-
 def reconnect():
   s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
   s.connect((ingest_host, ingest_port))
@@ -69,18 +62,20 @@ def send_message(message):
         print("Sent message to %s" % (k))
     except Exception as e:
       print('Error sending message: %s' % e)
-      sockets[k] = reconnect()
+      sock.connect(sock.getpeername())
+      sockets[k] = sock
+      print("Reconnected to %s:%d" % (sock.getpeername()))
       sockets[k].sendall(message.encode('utf-8'))
 
 
 if __name__ == '__main__':
   args_parser = argparse.ArgumentParser(
     prog = 'iridium-acars-to-airframes.py',
-    description='Feed Iridium ACARS to Airframes.io'
+    description='Feed Iridium ACARS to Airframes.io and additional remote destinations',
   )
   args_parser.add_argument('--station', '-s', help='Override station ident', required=False)
   args_parser.add_argument('--debug', '-d', help='Enable debug output', action='store_true')
-  args_parser.add_argument('--output', '-o', help='Send output via TCP to additional destination host:port', default=['%s:%s' % (airframes_ingest_host, airframes_ingest_port)], action='append')
+  args_parser.add_argument('--output', '-o', help='Send output via TCP to additional destination transport:host:port (where transport is "tcp" or "udp")', default=['tcp:%s:%s' % (airframes_ingest_host, airframes_ingest_port)], action='append')
   args = args_parser.parse_args()
 
   debug = args.debug
@@ -88,13 +83,22 @@ if __name__ == '__main__':
     print("Overriding station ident to %s" % (args.station,))
 
   for output in args.output:
-    host, port = output.split(':')
+    transport, host, port = output.split(':')
     try:
-      sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-      sock.connect((host, int(port)))
-      sockets[output] = sock
-      if debug:
-        print("Connected to %s:%s" % (host, port))
+      if transport == 'tcp':
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect((host, int(port)))
+        sockets[output] = sock
+        if debug:
+          print("Connected to %s:%s:%s" % (transport, host, port))
+      elif transport == 'udp':
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.connect((host, int(port)))
+        sockets[output] = sock
+        if debug:
+          print("Connected to %s:%s:%s" % (transport, host, port))
+      else:
+        print("Unknown transport %s" % (transport,))
     except TimeoutError as e:
       print("Error connecting to output (%s:%s): %s" % (host, port, e))
       sys.exit(1)

--- a/iridium-acars-to-airframes.py
+++ b/iridium-acars-to-airframes.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+#
+# iridium-acars-to-airframes.py
+#
+# Send the ACARS JSON output from iridium-toolkit to Airframes.io. You may send to additional outputs by
+# specifying the --output option multiple times.
+#
+# INSTRUCTIONS:
+#
+# 1. Ensure that your iridium-toolkit setup is properly decoding acars first.
+# 2. Pipe the output of the "-m acars -a json" to this script. Make sure you set your station ident!
+# 3. Optionally, specify additional outputs with the --output option.
+#
+# EXAMPLE:
+#
+#  $ export PYTHONUNBUFFERED=x
+#  $ reassembler.py -i zmq: -m acars -a json --station YOUR_STATION_IDENT | acars-to-airframes.py
+#
+# USAGE:
+#
+#   iridium-acars-to-airframes.py [-h] [--station STATION] [--debug] [--output OUTPUT]
+#
+#   Feed Iridium ACARS to Airframes.io
+#
+#   options:
+#     -h, --help            show this help message and exit
+#     --station STATION, -s STATION
+#                           Override station ident
+#     --debug, -d           Enable debug output
+#     --output OUTPUT, -o OUTPUT
+#                           Send output via TCP to additional destination host:port
+#
+# For more information about Airframes, see https://app.airframes.io/about or contact kevin@airframes.io.
+#
+
+import argparse
+import json
+import sys
+import select
+import time
+import socket
+
+airframes_ingest_host = 'feed.airframes.io'
+airframes_ingest_port = 5590
+debug = True
+sock = None
+sockets = {}
+
+def connect():
+  s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+  s.connect((ingest_host, ingest_port))
+  if debug:
+    print("Connected to Airframes Iridium ACARS ingest (%s:%d)" % (ingest_host, ingest_port))
+  return s
+
+def reconnect():
+  s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+  s.connect((ingest_host, ingest_port))
+  if debug:
+    print("Reconnected to Airframes Iridium ACARS ingest (%s:%d)" % (ingest_host, ingest_port))
+  return s
+
+def send_message(message):
+  global sockets
+  for k, sock in sockets.items():
+    try:
+      sock.sendall(("%s\n" % message).encode())
+      if debug:
+        print("Sent message to %s" % (k))
+    except Exception as e:
+      print('Error sending message: %s' % e)
+      sockets[k] = reconnect()
+      sockets[k].sendall(message.encode('utf-8'))
+
+
+if __name__ == '__main__':
+  args_parser = argparse.ArgumentParser(
+    prog = 'iridium-acars-to-airframes.py',
+    description='Feed Iridium ACARS to Airframes.io'
+  )
+  args_parser.add_argument('--station', '-s', help='Override station ident', required=False)
+  args_parser.add_argument('--debug', '-d', help='Enable debug output', action='store_true')
+  args_parser.add_argument('--output', '-o', help='Send output via TCP to additional destination host:port', default=['%s:%s' % (airframes_ingest_host, airframes_ingest_port)], action='append')
+  args = args_parser.parse_args()
+
+  debug = args.debug
+  if args.station and debug:
+    print("Overriding station ident to %s" % (args.station,))
+
+  for output in args.output:
+    host, port = output.split(':')
+    try:
+      sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+      sock.connect((host, int(port)))
+      sockets[output] = sock
+      if debug:
+        print("Connected to %s:%s" % (host, port))
+    except TimeoutError as e:
+      print("Error connecting to output (%s:%s): %s" % (host, port, e))
+      sys.exit(1)
+    except Exception as e:
+      print("Error connecting to output (%s:%s): %s" % (host, port, e))
+      print("Not adding output to (%s:%s)" % (host, port))
+
+  while True:
+    line = sys.stdin.readline().strip()
+    if debug:
+      print("Received: %s" % (line,))
+
+    try:
+      message = json.loads(line)
+    except Exception as e:
+      print("Error parsing JSON (%s): %s" % (e, line,))
+      continue
+
+    if args.station:
+      if message['source'] is None:
+        message['source'] = {}
+      message['source']['station'] = args.station
+
+    send_message(json.dumps(message))

--- a/iridium-acars-to-airframes.py
+++ b/iridium-acars-to-airframes.py
@@ -62,10 +62,11 @@ def send_message(message):
         print("Sent message to %s" % (k))
     except Exception as e:
       print('Error sending message: %s' % e)
-      sock.connect(sock.getpeername())
-      sockets[k] = sock
-      print("Reconnected to %s:%d" % (sock.getpeername()))
-      sockets[k].sendall(message.encode('utf-8'))
+      if socket.transport == 'tcp':
+        sock.connect(sock.getpeername())
+        sockets[k] = sock
+        print("Reconnected to %s:%d" % (sock.getpeername()))
+        sockets[k].sendall(message.encode('utf-8'))
 
 
 if __name__ == '__main__':
@@ -75,13 +76,14 @@ if __name__ == '__main__':
   )
   args_parser.add_argument('--station', '-s', help='Override station ident', required=False)
   args_parser.add_argument('--debug', '-d', help='Enable debug output', action='store_true')
-  args_parser.add_argument('--output', '-o', help='Send output via TCP to additional destination transport:host:port (where transport is "tcp" or "udp")', default=['tcp:%s:%s' % (airframes_ingest_host, airframes_ingest_port)], action='append')
+  args_parser.add_argument('--output', '-o', help='Send output via TCP to additional destination transport:host:port (where transport is "tcp" or "udp")', default=[], action='append')
   args = args_parser.parse_args()
 
   debug = args.debug
   if args.station and debug:
     print("Overriding station ident to %s" % (args.station,))
 
+  args.output = ['tcp:%s:%d' % (airframes_ingest_host, airframes_ingest_port)] + args.output
   for output in args.output:
     transport, host, port = output.split(':')
     try:


### PR DESCRIPTION
This builds on previous work I did to add JSON output to the ACARS parser. It augments the output to be in the format that Airframes is expecting, and also adds a script that can be piped to in order to send the output. The sender script also supports having additional remote outputs.

Example usage:
```bash
$ export PYTHONUNBUFFERED=x; ./reassembler.py -i zmq: -m acars -a json --station YOUR_STATION_IDENT | ./iridium-acars-to-airframes.py
```

In order to send to additional outputs, simply add `-o tcp:hostname:port` as many times to the `iridium-acars-to-airframes.py` command.