### PR TITLE
time as UTC, remove useless offset formatter

### DIFF
--- a/iridiumtk/reassembler/sbd.py
+++ b/iridiumtk/reassembler/sbd.py
@@ -322,7 +322,7 @@ class ReassembleIDASBDACARS(ReassembleIDASBD):
         if q.label == b'_\x7f' and 'nopings' in config.args:
             return
 
-        q.timestamp = datetime.datetime.fromtimestamp(q.time).strftime("%Y-%m-%dT%H:%M:%S%z")
+        q.timestamp = dt.epoch(q.time).isoformat(timespec='seconds')
 
         while len(q.f_reg)>0 and q.f_reg[0:1]==b'.':
             q.f_reg=q.f_reg[1:]


### PR DESCRIPTION
Opening this to address an issue raised [here](https://github.com/jcdeimos/acars_vdlm2_parser/pull/10)

Two parts to this little change:
1. remove the useless %z format spec. The exisiting `fromtimestamp()` call does not have a timezone specified, so the resulting `datetime` [is naive](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp), which means the `%z` specifier resolves to an [empty string](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes).
2. Add the UTC timezone to the `fromtimestamp` call. Without this the `datetime` object represents the time in the users local timezone but the object does not have any indication of what timezone it represents.

I think @kevinelliott would probably also like this change, or at least be indifferent, as regards Airframes ingest.