### PR TITLE
beam-plotter set_window_title error

### DIFF
--- a/beam-plotter.py
+++ b/beam-plotter.py
@@ -210,7 +210,7 @@ if direction is not None:
         raise
 
 plt.title(title)
-fig.canvas.set_window_title(title)
+fig.canvas.manager.set_window_title(title)
 
 # Make plot area larger
 fig.tight_layout()


### PR DESCRIPTION
If using matplotlib 3.6, the following error is raised:

```
Traceback (most recent call last):
  File "/home/user/iridium-toolkit/beam-plotter.py", line 213, in <module>
    fig.canvas.set_window_title(title)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'FigureCanvasAgg' object has no attribute 'set_window_title'
```

This can be fixed by replacing `fig.canvas.set_window_title(title)` with `fig.canvas.manager.set_window_title(title)`