### PR TITLE
add Certus IC1/IC2/IC8 classification + merge experimental-new-pkt

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -178,7 +178,23 @@ Notes:
 
 ### INP: "new packet"
 
-Work in progress.
+Work in progress. Simplex-DL burst format distinct from Block1 channels, seen in captures on 1626.40-1626.52 MHz. Each burst carries a 96-bit header (three 32-bit hdr words), up to 18 data blocks of 40 bits, and a 24-bit trailer.
+
+Header variants (selected by `hdr[1][4:8]`):
+
+- `H:1` (`hdr_id in {1000, 0111}`): `[hdr0:32][hdr1:32][data:16][CRC8][tail:8]`. CRC scope = 80 bits.
+- `H:2` (`hdr_id == 0110`): `[hdr0:32][hdr1:32][CRC8][tail:24]`. CRC scope = 72 bits. Source IDs observed so far are disjoint from H:1, suggesting a distinct beam/sat role.
+- `H:0`: any other `hdr_id`, layout not yet resolved.
+
+Types v1/v2/v3 depend on which CRC variant validates; see `IridiumNPMessage` for the exact logic.
+
+#### source_id split heuristic
+
+The `:NNNNN` value after the frame header is a 14-bit `source_id` extracted from `s2s[0][10:24]`. In our captures it partitions cleanly as `[sv_id:8][beam_id:6]`, i.e. `sv_id = source_id >> 6` and `beam_id = source_id & 0x3f`. This split is heuristic and not universally validated - some `hdr[0]` values span many sv_ids - so the fields are printed with a `?` marker:
+
+    INP: ... :04294 sv?:067 bm?:06 H:2 T:0 h<...>
+
+Consumers should treat `sv?` / `bm?` as best-effort interpretation, not authoritative decode.
 
 ### IC1 / IC2 / IC8: Iridium Certus (NEXT / EBBS) traffic bursts
 

--- a/FORMAT.md
+++ b/FORMAT.md
@@ -180,6 +180,36 @@ Notes:
 
 Work in progress.
 
+### IC1 / IC2 / IC8: Iridium Certus (NEXT / EBBS) traffic bursts
+
+Recognizer for Iridium NEXT Certus traffic channel bursts carrying user voice or IP data. Same 0x789 unique word as Block1 channels, but the rest of the waveform uses coherent QPSK (or 16APSK) with Turbo FEC instead of DEQPSK with BCH. The Block1-oriented demod pipeline emits differentially-decoded bits that are not directly meaningful for these bursts, so we classify them by symbol count alone and expose the raw (wrongly-decoded) bits for diagnostic purposes.
+
+Symbol counts and modulations consistent with publicly documented Certus bearers:
+
+| Tag | Symbol count | Modulation | Code | Payload bits |
+|---|---|---|---|---|
+| `IC1` | 200 | QPSK 4/5 | Turbo rate 4/5 | 320 |
+| `IC2` | 432 | QPSK 2/3 | Turbo rate 2/3 | 576 |
+| `IC8` | 1824 | QPSK 2/3 or 16APSK 2/3 | Turbo rate 2/3 | 2432 or 4848 |
+
+Example:
+
+    IC2: [...] 432 DL raw:0011001111110011 0011001101100011 [...]
+
+Column|Content|Example|Comment
+--:|-|-|-
+8|Length in symbols|432|200 for C1, 432 for C2, 1824 for C8
+9|Direction|DL|Certus L-band simplex downlink (1626.1-1626.5 MHz)
+10|raw:|raw:\<all bits\>|Raw demod output - NOT directly decodable in this form
+
+Notes and caveats:
+
+1. These bits are not the payload. The gr-iridium demodulator applies differential decoding unconditionally. That is correct for Block1 DEQPSK but wrong for coherent-QPSK Certus. Proper decoding requires a gr-iridium patch to expose the coherent-QPSK symbols before differential decode, followed by the Iridium-specific Turbo decoder and interleaver.
+2. Interleaver not public. The Iridium-NEXT-specific interleaver and puncturing patterns are not publicly documented; without them, Turbo decoding will not recover user data even with the correct bits.
+3. The recognizer only covers NEXT traffic (C1/C2/C8). DBCCH and other new broadcast channels are not currently detected.
+4. The current recognizer does not distinguish 16APSK-modulated C8 bursts from QPSK-modulated variants - both produce the same per-symbol count in the demod output.
+5. The paper "Systematic Security Analysis of the Iridium Satellite Radio Link" (Jedermann et al., USENIX Security 2026, arXiv:2603.12062) covers the Iridium radio link in depth and is a recommended follow-up reference.
+
 ### IBC: Broadcast
 
     IBC: [...] bc:0 sat:028 cell:32 0 slot:0 sv_blkn:0 aq_cl:1111111111111111 aq_sb:22 aq_ch:2 00 0000 tmsi_expiry:2020-06-25T14:18:30.44Z [0 Rid:119 ts:1 ul_sb:22 dl_sb:22 access:3 dtoa:001 dfoa:00 00] []

--- a/bitsparser.py
+++ b/bitsparser.py
@@ -846,11 +846,11 @@ class IridiumSTLMessage(IridiumMessage):
                 if x in itl.MAP_PRS:
                     self.msg.append(itl.MAP_PRS[x])
                 else:
-                    if i==0 or self.msg[0] != 108: # special message does not contain normal PRS
+                    if i == 0 or self.msg[0] not in (108, 109): # special message does not contain normal PRS
                         raise ParserError("ITL V2 PRS Q#%d unknown"%i)
                     self.msg.append(x)
 
-            if self.msg[0] != 108:
+            if self.msg[0] not in (108, 109):
                 #sanity check the PRS sequence order
                 sanity = "".join([str(itl.MAP_PRS_TYPE[x]) for x in self.q])
                 if self.plane%2 == 0:
@@ -878,7 +878,7 @@ class IridiumSTLMessage(IridiumMessage):
             cat=None
             for qidx in range(len(self.q)):
                 mindist=999
-                if qidx > 0 and self.msg[0] == 108:
+                if qidx > 0 and self.msg[0] in (108, 109):
                     self.msg[qidx]=self.q[qidx]
                     next
                 if self.q[qidx] in itl.MAP_PRS:

--- a/bitsparser.py
+++ b/bitsparser.py
@@ -340,7 +340,6 @@ class IridiumMessage(Message):
         if "msgtype" not in self.__dict__: # and (not args.freqclass or self.frequency > f_simplex) and not (args.freqclass and self.uplink):
             if len(data)==432*2:
                 symbols=de_dqpsk(data)
-                (i_list,q_list)=split_qpsk(symbols)
                 bits=sym2bits(symbols)
 
                 bits=bits[:160]
@@ -881,14 +880,14 @@ class IridiumNPMessage(IridiumMessage):
 
         # Begin pkts
         self.type=0
-        self.hdr=hdr
-        self.trailer=trailer
-        self.blocks=blocks
+        self.hdr=hdr         # 3 blocks a 32 bits
+        self.trailer=trailer # 24 bits
+        self.blocks=blocks   # 18 blocks a 40 bits
         self.checks=checks
 
         # Pkt v1
-        self.cs_v1=trailer[-16:]
-        self.v1trail=trailer[:-16]
+        self.v1trail=trailer[:8]
+        self.cs_v1=trailer[8:]
 
         self.the_crc_v1=np_crc16(bytes( [int(x,2) for x in slice(
                     hdr[-1][-8:]+
@@ -903,13 +902,13 @@ class IridiumNPMessage(IridiumMessage):
         csblocks=[b[:32] for b in blocks]
         self.csblocks=csblocks
 
-        self.cs_v2=self.trailer[-24:-8]
-        self.v2trail=self.trailer[-8:]
+        self.cs_v2=self.trailer[:16]
+        self.v2trail=self.trailer[16:]
 
         self.the_crc_v2=np_crc16(bytes([int(x,2) for x in slice(
                             hdr[-1][-8:]+
                             "".join(csblocks)+
-                            trailer[-24:-8]
+                            trailer[:16]
                         ,8)]))
 
         if self.the_crc_v2==0:
@@ -950,7 +949,7 @@ class IridiumNPMessage(IridiumMessage):
                 st+="[no]"
             st+= " "
             st+= " " # alignment
-            st+= self.hdr[2][8:]
+            st+= self.hdr[2][8:] # 24 bit
         else:
             st+= self.hdr[0] + " " + self.hdr[1] + " " + self.hdr[2]
         st+=">"
@@ -963,7 +962,7 @@ class IridiumNPMessage(IridiumMessage):
             st=st[:-1]
             st+=">"
 
-            st+= " t<"+" ".join(slice(self.v1trail,8))+">"
+            st+= " t<"+self.v1trail+">"
             st+= " CRC=%04x"%int(self.cs_v1,2)
             if self.the_crc_v1==0:
                 st+="[OK]"
@@ -979,15 +978,14 @@ class IridiumNPMessage(IridiumMessage):
             st=st[:-1]
             st+=">"
 
-            st+=" ["+self.blocks[-1]+"]"
-
             st+= " CRC=%04x"%int(self.cs_v2,2)
             if self.the_crc_v2==0:
                 st+="[OK]"
             else:
                 st+="[no]"
 
-            st+= " t<"+" ".join(slice(self.trailer,8))+">"
+            st+= " t<"+self.v2trail +">"
+
             if all(self.checks):
                 st+=" MAGC"
             else:

--- a/bitsparser.py
+++ b/bitsparser.py
@@ -968,7 +968,7 @@ class IridiumNPMessage(IridiumMessage):
                 st+="[OK]"
             else:
                 st+="[no]"
-            st+= "     " # alignment
+            st+= "       " # alignment
         elif self.type==2:
             st+= " d<"
             for x in self.csblocks:
@@ -985,6 +985,12 @@ class IridiumNPMessage(IridiumMessage):
                 st+="[no]"
 
             st+= " t<"+self.v2trail +">"
+            # Trailer checksum: previous block + crc
+            ok, _=magic_checksum2(self.csblocks[-1]+self.trailer)
+            if ok:
+                st+="OK"
+            else:
+                st+="no"
 
             if all(self.checks):
                 st+=" MAGC"
@@ -2320,6 +2326,23 @@ def magic_checksum(bits):
 
     # bit 4 & 5 are the "check value"
     if (check^cv) == 0b11000:
+        return True, check^cv
+    return False, check^cv
+
+# Second version of magic checksum
+# Input is 56 bits. 48 bits "data" and 8 bits "checksum"
+def magic_checksum2(bits):
+    cv=int(bits[32+16:],2)
+    bits=bits[:32+16]
+
+    magic=[44, 52, 28, 100, 4, 4, 100, 28, 4, 124, 28, 28, 124, 4, 52, 44, 56, 32, 8, 112, 16, 16, 112, 8, 71, 111, 83, 99, 99, 99, 51, 27, 22, 70, 26, 42, 74, 50, 82, 98, 93, 109, 13, 117, 21, 37, 41, 121]
+
+    check=0
+    for i, bit in enumerate(bits):
+        if bit=="1":
+            check^=magic[i]
+
+    if (check^cv) == 0b1111000:
         return True, check^cv
     return False, check^cv
 

--- a/bitsparser.py
+++ b/bitsparser.py
@@ -985,8 +985,8 @@ class IridiumNPMessage(IridiumMessage):
                 st+="[no]"
 
             st+= " t<"+self.v2trail +">"
-            # Trailer checksum: previous block + crc
-            ok, _=magic_checksum2(self.csblocks[-1]+self.trailer)
+            # Trailer checksum 'steals' two bytes from the previous block
+            ok, _=magic_checksum(self.blocks[-1][-16:]+self.trailer)
             if ok:
                 st+="OK"
             else:
@@ -2326,23 +2326,6 @@ def magic_checksum(bits):
 
     # bit 4 & 5 are the "check value"
     if (check^cv) == 0b11000:
-        return True, check^cv
-    return False, check^cv
-
-# Second version of magic checksum
-# Input is 56 bits. 48 bits "data" and 8 bits "checksum"
-def magic_checksum2(bits):
-    cv=int(bits[32+16:],2)
-    bits=bits[:32+16]
-
-    magic=[44, 52, 28, 100, 4, 4, 100, 28, 4, 124, 28, 28, 124, 4, 52, 44, 56, 32, 8, 112, 16, 16, 112, 8, 71, 111, 83, 99, 99, 99, 51, 27, 22, 70, 26, 42, 74, 50, 82, 98, 93, 109, 13, 117, 21, 37, 41, 121]
-
-    check=0
-    for i, bit in enumerate(bits):
-        if bit=="1":
-            check^=magic[i]
-
-    if (check^cv) == 0b1111000:
         return True, check^cv
     return False, check^cv
 

--- a/bitsparser.py
+++ b/bitsparser.py
@@ -338,7 +338,7 @@ class IridiumMessage(Message):
                     self.msgtype = "AQ"
 
         if "msgtype" not in self.__dict__: # and (not args.freqclass or self.frequency > f_simplex) and not (args.freqclass and self.uplink):
-            if len(data)==432*2:
+            if len(data)>=170:#==432*2:
                 symbols=de_dqpsk(data)
                 bits=sym2bits(symbols)
 
@@ -822,19 +822,38 @@ class IridiumNPMessage(IridiumMessage):
         if "header" not in self.__dict__:
             self.header=""
 
-        # Re-sort bits
-        trailer=bits[800::2]+bits[801::2]
-        bits=bits[:800]
+            # Re-sort bits
+        if len(bits)<840:
+            bcnt=len(bits)//160
+            trailer=bits[160*bcnt::]
+            bits=bits[:160*bcnt]
 
-        s1s=slice(bits[0::4],40)
-        s2s=slice(bits[1::4],40)
-        s3s=slice(bits[2::4],40)
-        s4s=slice(bits[3::4],40)
+            s1s=slice(bits[0::4],40)
+            s2s=slice(bits[1::4],40)
+            s3s=slice(bits[2::4],40)
+            s4s=slice(bits[3::4],40)
 
-        blocks=list(itertools.chain.from_iterable(zip(s1s,s2s,s3s,s4s)))
+            blocks=list(itertools.chain.from_iterable(zip(s1s,s2s,s3s,s4s)))
 
-        blocks+=[trailer[:40]]
-        trailer=trailer[40:]
+#            btrail=blocks[-4:]
+#            blocks=blocks[:-4]
+#            trailer="".join(btrail)+trailer
+
+#            blocks+=[blocks[-2][-8:]+btrail[0][:32]]
+#            blocks+=[btrail[1]]
+        else:
+            trailer=bits[800::2]+bits[801::2]
+            bits=bits[:800]
+
+            s1s=slice(bits[0::4],40)
+            s2s=slice(bits[1::4],40)
+            s3s=slice(bits[2::4],40)
+            s4s=slice(bits[3::4],40)
+
+            blocks=list(itertools.chain.from_iterable(zip(s1s,s2s,s3s,s4s)))
+
+            blocks+=[trailer[:40]]
+            trailer=trailer[40:]
 
         checks=[magic_checksum(b)[0] for b in blocks]
 

--- a/bitsparser.py
+++ b/bitsparser.py
@@ -994,7 +994,14 @@ class IridiumNPMessage(IridiumMessage):
         if all(checks[:-3]) and not any(checks[-3:]):
             self.type=3
 
-        self.header+=":%05d"%(int(s2s[0][10:24],2))
+        # source_id: 14-bit field at s2s[0][10:24]. In captures the value
+        # partitions as [sv_id:8][beam_id:6]; the split is heuristic (partial
+        # empirical support only), so pretty() marks both fields with "?"
+        # to discourage treating them as authoritative.
+        self.source_id=int(s2s[0][10:24],2)
+        self.sv_id_guess=(self.source_id>>6) & 0xff
+        self.beam_id_guess=self.source_id & 0x3f
+        self.header+=":%05d"%self.source_id
         return
 
     def upgrade(self):
@@ -1003,6 +1010,7 @@ class IridiumNPMessage(IridiumMessage):
     def pretty(self):
         st= "INP: "+self._pretty_header()
 
+        st+= " sv?:%03d bm?:%02d"%(self.sv_id_guess, self.beam_id_guess)
         st+= " H:%d"%self.hdr_type
         st+= " T:%d"%self.type
 

--- a/bitsparser.py
+++ b/bitsparser.py
@@ -27,6 +27,18 @@ NXT_UW_DOWNLINK = [2,2,0,2,2,0,2,0,2,0,2,2]
 NXT_UW_UPLINK   = [0,2,0,0,0,0,0,0,2,0,2,0]
 header_messaging="00110011111100110011001111110011" # 0x9669 in BPSK
 header_time_location="11"+"0"*94
+# Iridium Certus (NEXT / EBBS) traffic bursts. Same 0x789 unique word as all other
+# Iridium channels, but coherent QPSK + Turbo coding (not DEQPSK + BCH).
+# Symbol counts per publicly documented NEXT traffic bearers:
+#   C1 30ksps QPSK 4/5: 320 payload bits -> 400 coded -> 200 symbols
+#   C2 60ksps QPSK 2/3: 576 payload bits -> 864 coded -> 432 symbols
+#   C8 240ksps QPSK 2/3: 2432 payload bits -> 3648 coded -> 1824 symbols
+# The raw bits we see here are the *differentially-decoded* form of the coherent
+# QPSK symbols (diff-decode is applied unconditionally in gr-iridium). That's
+# wrong for Certus - the underlying demodulation is coherent, not differential -
+# so these bits are not directly payload-recoverable without a gr-iridium patch.
+# We recognize them by symbol count and simplex-DL band alone; the payload is left
+# as-is for future research (Turbo decoding + correct interleaver required).
 messaging_bch_poly=1897
 ringalert_bch_poly=1207
 acch_bch_poly=3545 # 1207 also works?
@@ -285,6 +297,23 @@ class IridiumMessage(Message):
             self._new_error("filtered message")
             return
 
+        # Certus (EBBS / NEXT) traffic burst recognition. Classify by symbol count on the
+        # simplex DL band - the bits themselves are not meaningful (wrong demod path for
+        # coherent QPSK + Turbo) but labeling them prevents the frame dropping to "unknown".
+        if "msgtype" not in self.__dict__ and (not args.freqclass or self.frequency > f_simplex) and not (args.freqclass and self.uplink):
+            # symbols field counts total symbols including the 12-symbol UW; subtract it for payload length.
+            payload_syms = self.symbols - (len(iridium_access) // 2)
+            if payload_syms == 200:
+                self.msgtype="C1"  # NEXT C1 30ksps QPSK 4/5, 320 payload bits
+            elif payload_syms == 432:
+                self.msgtype="C2"  # NEXT C2 60ksps QPSK 2/3, 576 payload bits
+            elif payload_syms == 1824:
+                self.msgtype="C8"  # NEXT C8 240ksps QPSK 2/3 (or 16APSK 2/3), 2432 / 4848 payload bits
+
+        if "msgtype" not in self.__dict__ and args.linefilter['type'] == "IridiumCertusMessage":
+            self._new_error("filtered message")
+            return
+
         if "msgtype" not in self.__dict__ and (not args.freqclass or self.frequency < f_duplex) and not (args.freqclass and self.uplink):
             hdrlen=6
             blocklen=64
@@ -390,6 +419,19 @@ class IridiumMessage(Message):
                         self.ec_lcw=1
                         self.msgtype="MS"
 
+                # try Certus traffic bursts by length alone under --harder
+                if "msgtype" not in self.__dict__ and not (args.freqclass and self.uplink):
+                    payload_syms = self.symbols - (len(iridium_access) // 2)
+                    if payload_syms == 200:
+                        self.ec_lcw=1
+                        self.msgtype="C1"
+                    elif payload_syms == 432:
+                        self.ec_lcw=1
+                        self.msgtype="C2"
+                    elif payload_syms == 1824:
+                        self.ec_lcw=1
+                        self.msgtype="C8"
+
         if "msgtype" not in self.__dict__:
             if len(data)<64:
                 raise ParserError("Iridium message too short")
@@ -409,6 +451,14 @@ class IridiumMessage(Message):
             (blocks,self.descramble_extra)=slice_extra(data[hdrlen:],64)
             for x in blocks:
                 self.descrambled+=de_interleave(x)
+        elif self.msgtype in ("C1", "C2", "C8"):
+            # Certus (NEXT / EBBS) traffic burst - carry raw bits through unchanged.
+            # The differential decoding that gr-iridium applies is incorrect for
+            # coherent-QPSK Certus waveforms, so these bits are not directly decodable.
+            # We still expose them so downstream tooling can look at them.
+            self.header=""
+            self.descrambled=data
+            self.descramble_extra=""
         elif self.msgtype=="AQ":
             datalen=2*26
             self.header=""
@@ -499,6 +549,8 @@ class IridiumMessage(Message):
                 return IridiumAQMessage(self).upgrade()
             elif self.msgtype in ("MS", "RA", "BC"):
                 return IridiumECCMessage(self).upgrade()
+            elif self.msgtype in ("C1", "C2", "C8"):
+                return IridiumCertusMessage(self)
             elif self.msgtype == "NX":
                 return IridiumNXTMessage(self).upgrade()
             raise AssertionError("unknown frame type encountered")
@@ -1971,6 +2023,68 @@ class IridiumNXTMessage(IridiumMessage):
         st += group(self.descrambled[32:36], 2)
         st += " > "
         st += group(self.descrambled[36:], 10)
+        st += self._pretty_trailer()
+        return st
+
+# Inverse of gr-iridium's decode_deqpsk(), so callers can recover the original
+# coherent QPSK symbols from a .bits capture. gr-iridium applies diff-decode to
+# every burst unconditionally, which is correct for Block1 DEQPSK but wrong for
+# coherent-QPSK Certus. Since check_sync_word() in gr-iridium has already
+# validated the unique word against the coherent symbols (phase locked via PLL),
+# the diff-decode is a deterministic bijection and invertible from the bits alone.
+#
+# Forward (gr-iridium decode_deqpsk): out[i] = _DEQ_FWD[ (s[i] - s[i-1]) % 4 ]
+# Inverse:                            s[i] = (s[i-1] + _DEQ_INV[out[i]]) % 4
+_DEQ_FWD = (0, 2, 3, 1)
+_DEQ_INV = tuple(_DEQ_FWD.index(x) for x in range(4))  # (0, 3, 1, 2)
+
+def un_deqpsk(bits, seed_symbol=0):
+    """Invert decode_deqpsk on a bit string (2 bits per symbol, MSB-first).
+    seed_symbol is the coherent symbol that preceded the first bit pair - for
+    payload bits stripped of the UW, this is the last UW coherent symbol (=2
+    for UW_DL and UW_UL, both of which end with symbol 2).
+    Returns a bit string of the same length representing coherent QPSK symbols.
+    """
+    old = seed_symbol
+    out = []
+    for i in range(0, len(bits) - 1, 2):
+        sym_out = (int(bits[i]) << 1) | int(bits[i+1])
+        diff = _DEQ_INV[sym_out]
+        s = (old + diff) & 3
+        out.append('1' if s & 2 else '0')
+        out.append('1' if s & 1 else '0')
+        old = s
+    if len(bits) & 1:
+        out.append(bits[-1])  # stray bit pass-through (shouldn't happen)
+    return ''.join(out)
+
+class IridiumCertusMessage(IridiumMessage):
+    # Iridium Certus (NEXT / EBBS) traffic burst - coherent QPSK + Turbo-coded.
+    # Identified by symbol count on the simplex DL band:
+    #   C1 = 200 symbols, NEXT C1 30ksps QPSK 4/5 (320 payload bits)
+    #   C2 = 432 symbols, NEXT C2 60ksps QPSK 2/3 (576 payload bits)
+    #   C8 = 1824 symbols, NEXT C8 240ksps QPSK 2/3 or 16APSK 2/3 (2432 or 4848 payload bits)
+    #
+    # gr-iridium emits diff-decoded bits that are correct for Block1 DEQPSK but
+    # wrong for these. We recover the coherent QPSK symbols in un_deqpsk() and
+    # expose them as the payload. Turbo decoding of the resulting stream is left
+    # as future work (requires the Iridium-specific interleaver, puncturing
+    # pattern, and Turbo polynomial, none of which are publicly documented).
+    def __init__(self, imsg):
+        self.__dict__ = imsg.__dict__
+        # Seed from the last coherent UW symbol (UW_DL[11] = UW_UL[11] = 2).
+        self.coherent = un_deqpsk(self.descrambled, seed_symbol=2)
+
+    def upgrade(self):
+        if self.error: return self
+        return self
+
+    def pretty(self):
+        st = "I" + self.msgtype + ": " + self._pretty_header()   # "IC1:", "IC2:", "IC8:"
+        # Emit coherent QPSK bits (recovered), grouped per symbol-pair for
+        # readability. These are the actual transmitted QPSK symbols,
+        # pre-Turbo-decoded, in the 2-bits-per-symbol form Iridium uses.
+        st += " coh:" + group(self.coherent, 16)
         st += self._pretty_trailer()
         return st
 

--- a/bitsparser.py
+++ b/bitsparser.py
@@ -299,10 +299,10 @@ class IridiumMessage(Message):
             return
 
         # Certus (EBBS / NEXT) traffic burst recognition. Classify by symbol count on the
-        # simplex DL band - the bits themselves are not meaningful (wrong demod path for
-        # coherent QPSK + Turbo) but labeling them prevents the frame dropping to "unknown".
-        if "msgtype" not in self.__dict__ and (not args.freqclass or self.frequency > f_simplex) and not (args.freqclass and self.uplink):
-            # symbols field counts total symbols including the 12-symbol UW; subtract it for payload length.
+        # simplex DL band. Guarded on self.next so we only claim frames that used
+        # next_access_dl sync - stops us stealing IRA/VOC bursts that happen to have
+        # matching symbol counts on iridium_access.
+        if "msgtype" not in self.__dict__ and self.next and (not args.freqclass or self.frequency > f_simplex) and not (args.freqclass and self.uplink):
             payload_syms = self.symbols - (len(iridium_access) // 2)
             if payload_syms == 200:
                 self.msgtype="C1"  # NEXT C1 30ksps QPSK 4/5, 320 payload bits
@@ -452,7 +452,8 @@ class IridiumMessage(Message):
                         self.msgtype="MS"
 
                 # try Certus traffic bursts by length alone under --harder
-                if "msgtype" not in self.__dict__ and not (args.freqclass and self.uplink):
+                # guarded on self.next so we don't steal IRA/VOC bursts on iridium_access sync
+                if "msgtype" not in self.__dict__ and self.next and not (args.freqclass and self.uplink):
                     payload_syms = self.symbols - (len(iridium_access) // 2)
                     if payload_syms == 200:
                         self.ec_lcw=1

--- a/bitsparser.py
+++ b/bitsparser.py
@@ -341,17 +341,28 @@ class IridiumMessage(Message):
             if len(data)==432*2:
                 symbols=de_dqpsk(data)
                 (i_list,q_list)=split_qpsk(symbols)
-                l1=i_list[0::2] # a<0.111101 ....1011 ...11001 1...0001 1
-                l1_id=l1[2:8]+","+l1[12:16]+","+l1[19:25]+","+l1[28:33]
-                l3=q_list[0::2]
-                l3_id=l3[0:3]+","+l3[8:10]+","+l3[24:25]+l3[30:31]
-#                print("l1:",l1_id, "l3:", l3_id)
-                if l1_id=="111101,1011,110011,00011": # and id_part=="1111":
+                bits=sym2bits(symbols)
+
+                bits=bits[:160]
+                h1=bits[0::4]
+                h2=bits[1::4]
+                #            1         2         3            1         2         3
+                #  01234567890123456789012345678901 01234567890123456789012345678901
+                #h<01000010001101001100011001101110 00011000000000001111011000000000
+                #h<11000010011101000100011001111110 00010110000000110110110101000000
+                #    ++++++    ++++   ++++++   ++++ +++     ++                ++++++
+                h1_id=h1[2:8]+","+h1[12:16]+","+h1[19:25]+","+h1[28:32]
+                h2_id=h2[0:3]+","+h2[8:10]+","+h2[26:32]
+                if h1_id=="000010,0100,001100,1110" and h2_id=="000,00,000000":
                     self.msgtype="NP"
-                    if l1.startswith("0011110110001011011110011010000111100011011100101111100100011000100100011101011001010011"):
-                        self.header="V1"
-                    else:
-                        self.header="V0"
+                elif args.harder:
+                    h3=bits[2::4]
+                    ok1,_ = magic_checksum(h1)
+                    ok2,_ = magic_checksum(h2)
+                    ok3,_ = magic_checksum(h3)
+                    if ok1 and ok2 and ok3:
+                        self.ec_lcw=1
+                        self.msgtype="NP"
 
         if "msgtype" not in self.__dict__:
             if args.harder:
@@ -800,6 +811,7 @@ class IridiumAQMessage(IridiumMessage):
 
 
 np_crc16=crcmod.mkCrcFun(poly=0b10111010101011011,initCrc=0,rev=False,xorOut=0)
+np_crc8=crcmod.mkCrcFun(poly=0x12f,initCrc=0,rev=False,xorOut=0)
 
 class IridiumNPMessage(IridiumMessage):
     def __init__(self,imsg):
@@ -807,6 +819,9 @@ class IridiumNPMessage(IridiumMessage):
 
         symbols=de_dqpsk(self.descrambled)
         bits=sym2bits(symbols)
+
+        if "header" not in self.__dict__:
+            self.header=""
 
         # Re-sort bits
         trailer=bits[800::2]+bits[801::2]
@@ -845,6 +860,25 @@ class IridiumNPMessage(IridiumMessage):
         blocks=blocks[3:]
         checks=checks[3:]
 
+        hdr_id=hdr[1][4:8]
+
+        if hdr_id in ('1000','0111'):
+            self.hdr_type=1
+        elif hdr_id in ('0110',):
+            self.hdr_type=2
+        else:
+            self.hdr_type=0
+
+        # H1
+        self.hdr_crc1=np_crc8(bytes( [int(x,2) for x in slice(
+                    hdr[0]+hdr[1]+hdr[2][:-8]
+                ,8)]))
+
+        # H2
+        self.hdr_crc2=np_crc8(bytes( [int(x,2) for x in slice(
+                    hdr[0]+hdr[1]+hdr[2][:8]
+                ,8)]))
+
         # Begin pkts
         self.type=0
         self.hdr=hdr
@@ -881,6 +915,10 @@ class IridiumNPMessage(IridiumMessage):
         if self.the_crc_v2==0:
             self.type=2
 
+        # Pkt v3
+        if all(checks[:-3]) and not any(checks[-3:]):
+            self.type=3
+
         self.header+=":%05d"%(int(s2s[0][10:24],2))
         return
 
@@ -890,14 +928,32 @@ class IridiumNPMessage(IridiumMessage):
     def pretty(self):
         st= "INP: "+self._pretty_header()
 
+        st+= " H:%d"%self.hdr_type
         st+= " T:%d"%self.type
 
         st+= " h<"
-        for x in self.hdr:
-            st+= "".join(slice(x,8))
+        if self.hdr_type == 1:
+            st+= self.hdr[0] + " " + self.hdr[1] + " " + self.hdr[2][:-16]
+            st+=" CRC=%02x"%int(self.hdr[2][-16:-8],2)
+            if self.hdr_crc1==0:
+                st+="[OK]"
+            else:
+                st+="[no]"
             st+= " "
-        st=st[:-1]
-        st+="> "
+            st+= self.hdr[2][-8:]
+        elif self.hdr_type == 2:
+            st+= self.hdr[0] + " " + self.hdr[1]
+            st+=" CRC=%02x"%int(self.hdr[2][:8],2)
+            if self.hdr_crc2==0:
+                st+="[OK]"
+            else:
+                st+="[no]"
+            st+= " "
+            st+= " " # alignment
+            st+= self.hdr[2][8:]
+        else:
+            st+= self.hdr[0] + " " + self.hdr[1] + " " + self.hdr[2]
+        st+=">"
 
         if self.type==1:
             st+= " d<"
@@ -913,13 +969,17 @@ class IridiumNPMessage(IridiumMessage):
                 st+="[OK]"
             else:
                 st+="[no]"
+            st+= "     " # alignment
         elif self.type==2:
             st+= " d<"
             for x in self.csblocks:
                 st+= "".join(slice(x,8))
                 st+= " "
+                st+= "        " # alignment
             st=st[:-1]
             st+=">"
+
+            st+=" ["+self.blocks[-1]+"]"
 
             st+= " CRC=%04x"%int(self.cs_v2,2)
             if self.the_crc_v2==0:
@@ -927,15 +987,32 @@ class IridiumNPMessage(IridiumMessage):
             else:
                 st+="[no]"
 
-            st+= " t<"+" ".join(slice(self.v2trail,8))+">"
+            st+= " t<"+" ".join(slice(self.trailer,8))+">"
             if all(self.checks):
-                st+=" MAGIC"
+                st+=" MAGC"
             else:
-                st+=" nomag"
+                st+=" nomg"
+        elif self.type==3:
+            st+= " d<"
+            for x in self.csblocks[:-3]:
+                st+= "".join(slice(x,8))
+                st+= " "
+                st+= "        " # alignment
+            for x in self.blocks[-3:]:
+                st+= "".join(slice(x,8))
+                st+= " "
+            st=st[:-1]
+            st+=">"
+
+            st+= " t<"+" ".join(slice(self.trailer,8))+">"
         else:
             st+= " d<"
-            for x in self.blocks:
-                st+= "".join(slice(x,8))
+            for i,x in enumerate(self.blocks):
+                if self.checks[i]:
+                    st+= "".join(slice(x[:32],8))
+                    st+= "        " # alignment
+                else:
+                    st+= "".join(slice(x,8))
                 st+= " "
             st=st[:-1]
             st+=">"
@@ -944,6 +1021,8 @@ class IridiumNPMessage(IridiumMessage):
 
         st+= " v1=%04x"%(self.the_crc_v1)
         st+= " v2=%04x"%(self.the_crc_v2)
+        st+= " h1=%02x"%(self.hdr_crc1)
+        st+= " h2=%02x"%(self.hdr_crc2)
         st+= " magic=%s"%(self.magic)
 
         st+=self._pretty_trailer()

--- a/bitsparser.py
+++ b/bitsparser.py
@@ -2301,26 +2301,27 @@ def sym2bits(symbols):
 #
 # Input is 40 bits. 32 bits "data" and 8 bits "checksum"
 #
-# No idea how it is inteded to work, but it is almost
+# No idea how it is inteded to work, but it is
 # completely linear from input bits, so we can check it that
 # way, even if it is a bit convoluted.
 #
 # Checksum uses only lower 7 bits.
-# Additionally bits 4&5 are correlated, but depend on
-# something yet unknown.
+#
+# Initial/Zero value is bits 4&5.
 #
 def magic_checksum(bits):
     cv=int(bits[32:],2)
     bits=bits[:32]
 
-    magic=[79, 7, 67, 107, 11, 107, 11, 35, 4, 44, 76, 44, 76, 100, 104, 32, 14, 70, 2, 42, 74, 42, 74, 98, 69, 109, 13, 109, 13, 37, 41, 97, 24]
+    magic=[87, 7, 91, 107, 11, 115, 19, 35, 28, 44, 76, 52, 84, 100, 104, 56, 22, 70, 26, 42, 74, 50, 82, 98, 93, 109, 13, 117, 21, 37, 41, 121]
+
     check=0
     for i, bit in enumerate(bits):
         if bit=="1":
             check^=magic[i]
 
-    # bit 4 & 5 are correlated
-    if (check^cv) == 0 or (check^cv) == 0b11000:
+    # bit 4 & 5 are the "check value"
+    if (check^cv) == 0b11000:
         return True, check^cv
     return False, check^cv
 

--- a/bitsparser.py
+++ b/bitsparser.py
@@ -907,6 +907,8 @@ class IridiumNPMessage(IridiumMessage):
         # Pkt v1
         self.v1trail=trailer[:8]
         self.cs_v1=trailer[8:]
+        if self.cs_v1 == '':
+            self.cs_v1='0'
 
         self.the_crc_v1=np_crc16(bytes( [int(x,2) for x in slice(
                     hdr[-1][-8:]+
@@ -923,6 +925,8 @@ class IridiumNPMessage(IridiumMessage):
 
         self.cs_v2=self.trailer[:16]
         self.v2trail=self.trailer[16:]
+        if self.cs_v2 == '':
+            self.cs_v2='0'
 
         self.the_crc_v2=np_crc16(bytes([int(x,2) for x in slice(
                             hdr[-1][-8:]+

--- a/bitsparser.py
+++ b/bitsparser.py
@@ -7,6 +7,7 @@ import re
 import struct
 import fileinput
 import datetime
+import itertools
 from math import sqrt,atan2,pi,log
 
 import crcmod
@@ -336,6 +337,22 @@ class IridiumMessage(Message):
                 if 'e' not in sym:
                     self.msgtype = "AQ"
 
+        if "msgtype" not in self.__dict__: # and (not args.freqclass or self.frequency > f_simplex) and not (args.freqclass and self.uplink):
+            if len(data)==432*2:
+                symbols=de_dqpsk(data)
+                (i_list,q_list)=split_qpsk(symbols)
+                l1=i_list[0::2] # a<0.111101 ....1011 ...11001 1...0001 1
+                l1_id=l1[2:8]+","+l1[12:16]+","+l1[19:25]+","+l1[28:33]
+                l3=q_list[0::2]
+                l3_id=l3[0:3]+","+l3[8:10]+","+l3[24:25]+l3[30:31]
+#                print("l1:",l1_id, "l3:", l3_id)
+                if l1_id=="111101,1011,110011,00011": # and id_part=="1111":
+                    self.msgtype="NP"
+                    if l1.startswith("0011110110001011011110011010000111100011011100101111100100011000100100011101011001010011"):
+                        self.header="V1"
+                    else:
+                        self.header="V0"
+
         if "msgtype" not in self.__dict__:
             if args.harder:
                 # try IBC
@@ -424,6 +441,10 @@ class IridiumMessage(Message):
             self.header=data[:hdrlen]
             self.descrambled=data[hdrlen:hdrlen+(256*3)]
             self.descramble_extra=data[hdrlen+(256*3):]
+        elif self.msgtype=="NP":
+#            self.header=""
+            self.descrambled=data[:432*2]
+            self.descramble_extra=data[(432*2):]
         elif self.msgtype=="RA":
             firstlen=3*32
             if len(data)<firstlen:
@@ -500,6 +521,8 @@ class IridiumMessage(Message):
                 return IridiumLCWMessage(self).upgrade()
             elif self.msgtype=="TL":
                 return IridiumSTLMessage(self).upgrade()
+            elif self.msgtype=="NP":
+                return IridiumNPMessage(self).upgrade()
             elif self.msgtype=="AQ":
                 return IridiumAQMessage(self).upgrade()
             elif self.msgtype in ("MS", "RA", "BC"):
@@ -775,6 +798,156 @@ class IridiumAQMessage(IridiumMessage):
         st+=self._pretty_trailer()
         return st
 
+
+np_crc16=crcmod.mkCrcFun(poly=0b10111010101011011,initCrc=0,rev=False,xorOut=0)
+
+class IridiumNPMessage(IridiumMessage):
+    def __init__(self,imsg):
+        self.__dict__=imsg.__dict__
+
+        symbols=de_dqpsk(self.descrambled)
+        bits=sym2bits(symbols)
+
+        # Re-sort bits
+        trailer=bits[800::2]+bits[801::2]
+        bits=bits[:800]
+
+        s1s=slice(bits[0::4],40)
+        s2s=slice(bits[1::4],40)
+        s3s=slice(bits[2::4],40)
+        s4s=slice(bits[3::4],40)
+
+        blocks=list(itertools.chain.from_iterable(zip(s1s,s2s,s3s,s4s)))
+
+        blocks+=[trailer[:40]]
+        trailer=trailer[40:]
+
+        checks=[magic_checksum(b)[0] for b in blocks]
+
+        ### magic debug
+        ok=""
+        for b in blocks:
+            good, r = magic_checksum(b)
+#            print(b[32:],"%02x"%(r))
+            if good and b[32:]=="00000000":
+                ok+="o"
+            elif good:
+                ok+="O"
+            else:
+                ok+="n"
+        self.magic=ok
+        ### end magic
+
+        if not all(checks[:3]): # "INP"
+            raise ParserError("INP header not valid")
+
+        hdr=[b[:32] for b in blocks[:3]]
+        blocks=blocks[3:]
+        checks=checks[3:]
+
+        # Begin pkts
+        self.type=0
+        self.hdr=hdr
+        self.trailer=trailer
+        self.blocks=blocks
+        self.checks=checks
+
+        # Pkt v1
+        self.cs_v1=trailer[-16:]
+        self.v1trail=trailer[:-16]
+
+        self.the_crc_v1=np_crc16(bytes( [int(x,2) for x in slice(
+                    hdr[-1][-8:]+
+                    "".join(blocks)+
+                    trailer
+                ,8)]))
+
+        if self.the_crc_v1==0:
+            self.type=1
+
+        # Pkt v2
+        csblocks=[b[:32] for b in blocks]
+        self.csblocks=csblocks
+
+        self.cs_v2=self.trailer[-24:-8]
+        self.v2trail=self.trailer[-8:]
+
+        self.the_crc_v2=np_crc16(bytes([int(x,2) for x in slice(
+                            hdr[-1][-8:]+
+                            "".join(csblocks)+
+                            trailer[-24:-8]
+                        ,8)]))
+
+        if self.the_crc_v2==0:
+            self.type=2
+
+        self.header+=":%05d"%(int(s2s[0][10:24],2))
+        return
+
+    def upgrade(self):
+        return self
+
+    def pretty(self):
+        st= "INP: "+self._pretty_header()
+
+        st+= " T:%d"%self.type
+
+        st+= " h<"
+        for x in self.hdr:
+            st+= "".join(slice(x,8))
+            st+= " "
+        st=st[:-1]
+        st+="> "
+
+        if self.type==1:
+            st+= " d<"
+            for x in self.blocks:
+                st+= "".join(slice(x,8))
+                st+= " "
+            st=st[:-1]
+            st+=">"
+
+            st+= " t<"+" ".join(slice(self.v1trail,8))+">"
+            st+= " CRC=%04x"%int(self.cs_v1,2)
+            if self.the_crc_v1==0:
+                st+="[OK]"
+            else:
+                st+="[no]"
+        elif self.type==2:
+            st+= " d<"
+            for x in self.csblocks:
+                st+= "".join(slice(x,8))
+                st+= " "
+            st=st[:-1]
+            st+=">"
+
+            st+= " CRC=%04x"%int(self.cs_v2,2)
+            if self.the_crc_v2==0:
+                st+="[OK]"
+            else:
+                st+="[no]"
+
+            st+= " t<"+" ".join(slice(self.v2trail,8))+">"
+            if all(self.checks):
+                st+=" MAGIC"
+            else:
+                st+=" nomag"
+        else:
+            st+= " d<"
+            for x in self.blocks:
+                st+= "".join(slice(x,8))
+                st+= " "
+            st=st[:-1]
+            st+=">"
+
+            st+= " t<"+" ".join(slice(self.trailer,8))+">"
+
+        st+= " v1=%04x"%(self.the_crc_v1)
+        st+= " v2=%04x"%(self.the_crc_v2)
+        st+= " magic=%s"%(self.magic)
+
+        st+=self._pretty_trailer()
+        return st
 
 class IridiumSTLMessage(IridiumMessage):
     def __init__(self,imsg):
@@ -2037,6 +2210,40 @@ def de_dqpsk(bits):
         symbols[c]=(symbols[c-1]+symbols[c])%4
 
     return symbols
+
+def sym2bits(symbols):
+    bits=""
+    omap=["00","10","11","01"]
+    omap=["11","01","00","10"] # XXX: Negate everything.
+    bits="".join([omap[sym] for sym in symbols])
+    return bits
+
+# calculate "Magic" checksum
+#
+# Input is 40 bits. 32 bits "data" and 8 bits "checksum"
+#
+# No idea how it is inteded to work, but it is almost
+# completely linear from input bits, so we can check it that
+# way, even if it is a bit convoluted.
+#
+# Checksum uses only lower 7 bits.
+# Additionally bits 4&5 are correlated, but depend on
+# something yet unknown.
+#
+def magic_checksum(bits):
+    cv=int(bits[32:],2)
+    bits=bits[:32]
+
+    magic=[79, 7, 67, 107, 11, 107, 11, 35, 4, 44, 76, 44, 76, 100, 104, 32, 14, 70, 2, 42, 74, 42, 74, 98, 69, 109, 13, 109, 13, 37, 41, 97, 24]
+    check=0
+    for i, bit in enumerate(bits):
+        if bit=="1":
+            check^=magic[i]
+
+    # bit 4 & 5 are correlated
+    if (check^cv) == 0 or (check^cv) == 0b11000:
+        return True, check^cv
+    return False, check^cv
 
 def split_qpsk(symbols):
     i_list=""

--- a/bitsparser.py
+++ b/bitsparser.py
@@ -809,7 +809,7 @@ class IridiumAQMessage(IridiumMessage):
         return st
 
 
-np_crc16=crcmod.mkCrcFun(poly=0b10111010101011011,initCrc=0,rev=False,xorOut=0)
+np_crc16=crcmod.mkCrcFun(poly=0x1755b,initCrc=0,rev=False,xorOut=0)
 np_crc8=crcmod.mkCrcFun(poly=0x12f,initCrc=0,rev=False,xorOut=0)
 
 class IridiumNPMessage(IridiumMessage):

--- a/iridiumtk/reassembler/burst.py
+++ b/iridiumtk/reassembler/burst.py
@@ -54,7 +54,7 @@ class ReassembleMSGBurst(ReassembleMSG):
     multi = {}
 
     def process_l2(self, msg):
-        if not msg.correct:
+        if not msg.correct or not msg.fmt == 5:
             return
 
         ct = msg.content

--- a/iridiumtk/reassembler/ida.py
+++ b/iridiumtk/reassembler/ida.py
@@ -807,12 +807,10 @@ class ReassembleIDAPP(ReassembleIDA):
                     # 5: number of messages waiting to be delivered / backlog
                     # 6+7: "ack request" (answer: <50:xx:xx>) -- only for <26>
 
-                    if data[0]==0x26:
-#                        prehdr=data[:7]
+                    if data[0] == 0x26 or (data[0] == 0x20 and data[7] == 0x10):
                         prehdr="<%02x MTMSN=(%02x%02x) msgct:%d backlog=%d mid=(%02x:%02x)>"%(data[0],data[1],data[2],data[3],data[4],data[5],data[6])
                         data=data[7:]
                     elif data[0]==0x20:
-#                        prehdr=data[:5]
                         prehdr="<%02x MTMSN=(%02x%02x) msgct:%d backlog=%d>"%(data[0],data[1],data[2],data[3],data[4])
                         data=data[5:]
                     else:

--- a/iridiumtk/reassembler/msg.py
+++ b/iridiumtk/reassembler/msg.py
@@ -4,6 +4,8 @@
 import sys
 import datetime
 import re
+import base64
+import crcmod
 from util import to_ascii, slice_extra, dt
 
 from .base import *
@@ -67,12 +69,8 @@ class ReassembleMSG(Reassemble):
         self.err=re.compile(r' ERR:')
         self.msg=re.compile(r'.* ric:(\d+) fmt:(\d+) seq:(\d+) (?:C:(..)\S*|[01 ]+) (\d)/(\d) csum:([0-9a-f][0-9a-f]) msg:([0-9a-f]*)\.([01]*) ')
         self.ms3=re.compile(r'.* ric:(\d+) fmt:(\d+) seq:(\d+) [01]+ \d BCD: ([0-9a-f]+)')
-        if 'noburst' in config.args:
-            global base64
-            import base64
-            import crcmod
-            self.crc16 = crcmod.predefined.mkPredefinedCrcFun("xmodem")
-            self.BURST_TRANS = bytes.maketrans(b'*-',b'/=')
+        self.crc16 = crcmod.predefined.mkPredefinedCrcFun("xmodem")
+        self.BURST_TRANS = bytes.maketrans(b'*-', b'/=')
 
     def filter(self,line):
         q=super().filter(line)
@@ -182,15 +180,18 @@ class ReassembleMSG(Reassemble):
         date = dt.epoch_local(msg.time).isoformat(timespec='seconds')
         str="Message %07d %02d @%s (len:%d)"%(msg.ric, msg.seq, date, msg.pcnt)
         txt= msg.content
-        if 'noburst' in config.args:
-            try:
-                ct = txt.translate(self.BURST_TRANS)
-                dec = base64.b64decode(ct)
-                crcv = self.crc16(dec)
-                if crcv == 0:
-                    return
-            except Exception:
-                pass
+        try:
+            msg.burst = False
+            ct = txt.translate(self.BURST_TRANS)
+            dec = base64.b64decode(ct)
+            crcv = self.crc16(dec)
+            if crcv == 0:
+                msg.burst = True
+        except Exception:
+            pass
+
+        if 'noburst' in config.args and msg.burst:
+            return
 
         if msg.fmt==5:
             out=to_ascii(txt, escape=True)
@@ -198,7 +199,12 @@ class ReassembleMSG(Reassemble):
         elif msg.fmt==3:
             out=txt
             str+= " BCD"
-        str+= (" fail:","   OK:")[msg.correct]
+        if msg.burst and msg.correct:
+            str += "  GDB:"
+        elif msg.correct:
+            str += "   OK:"
+        else:
+            str += " fail:"
         str+= " %s"%(out)
         print(str, file=outfile)
 

--- a/iridiumtk/reassembler/pktstats.py
+++ b/iridiumtk/reassembler/pktstats.py
@@ -25,7 +25,7 @@ class LivePktStats(Reassemble):
         self.default={}
         for k in ['UL', 'DL']:
             self.default[k]={}
-            for x in ['IBC', 'IDA', 'IIP', 'IIQ', 'IIR', 'IIU', 'IMS', 'IRA', 'IRI', 'ISY', 'ITL', 'IU3', 'I36', 'I38', 'MSG', 'VDA', 'VO6', 'VOC', 'VOD', 'MS3', 'VOZ', 'IAQ', 'NXT']:
+            for x in ['IBC', 'IDA', 'IIP', 'IIQ', 'IIR', 'IIU', 'IMS', 'IRA', 'IRI', 'ISY', 'ITL', 'IU3', 'I36', 'I38', 'MSG', 'VDA', 'VO6', 'VOC', 'VOD', 'MS3', 'VOZ', 'IAQ', 'INP', 'NXT']:
                 self.default[k][x]=0
         pass
 

--- a/iridiumtk/reassembler/sbd.py
+++ b/iridiumtk/reassembler/sbd.py
@@ -59,11 +59,11 @@ class ReassembleIDASBD(ReassembleIDA):
         if data[0]==0x76:
             if ul:
                 if data[1]<0x0c or data[1]>0x0e:
-                    print("WARN: SBD: ul pkt with unclear type",data.hex(":"), file=sys.stderr)
+                    #print("WARN: SBD: ul pkt with unclear type",data.hex(":"), file=sys.stderr)
                     return
             else:
                 if data[1]<0x08 or data[1]>0x0b:
-                    print("WARN: SBD: dl pkt with unclear type",data.hex(":"), file=sys.stderr)
+                    #print("WARN: SBD: dl pkt with unclear type",data.hex(":"), file=sys.stderr)
                     return
 
         if data[0]==0x06:

--- a/iridiumtk/reassembler/sbd.py
+++ b/iridiumtk/reassembler/sbd.py
@@ -97,6 +97,12 @@ class ReassembleIDASBD(ReassembleIDA):
                 elif data[0]==0x20:
                     prehdr=data[:5]
                     data=data[5:]
+                    # sometimes it seems to be 7 bytes long
+                    if len(data) >= 2 and data[2] == 0x10:
+                        # first DL Message will have 0x01 in data[2], so
+                        # there should be no danger of misclassification
+                        prehdr += data[:2]
+                        data = data[2:]
                 else:
                     print("WARN: SBD: DL pkt with unclear header",data.hex(":"), file=sys.stderr)
                     prehdr=data[:7]

--- a/iridiumtk/reassembler/stats.py
+++ b/iridiumtk/reassembler/stats.py
@@ -7,7 +7,7 @@ import datetime
 from .base import *
 from ..config import config, outfile, state
 
-ft=['IBC', 'IDA', 'IIP', 'IIQ', 'IIR', 'IIU', 'IMS', 'IRA', 'IRI', 'ISY', 'ITL', 'IU3', 'I36', 'I38', 'MSG', 'VDA', 'VO6', 'VOC', 'VOD', 'MS3', 'VOZ', 'IAQ', 'NXT']
+ft=['IBC', 'IDA', 'IIP', 'IIQ', 'IIR', 'IIU', 'IMS', 'IRA', 'IRI', 'ISY', 'ITL', 'IU3', 'I36', 'I38', 'MSG', 'VDA', 'VO6', 'VOC', 'VOD', 'MS3', 'VOZ', 'IAQ', 'INP', 'NXT']
 
 class StatsPKT(Reassemble):
     stats={}

--- a/iridiumtk/reassembler/time.py
+++ b/iridiumtk/reassembler/time.py
@@ -4,9 +4,50 @@
 import sys
 import re
 from util import dt
+import numpy as np
 
 from .base import *
 from ..config import config, outfile
+
+early_frame = 3
+
+conv_start = None
+
+
+def lbfc_str(ts, start=0):
+    """Convert milliseconds into L-Band frame counter"""
+    global conv_start
+
+    if start != 0:
+        conv_start = start
+
+    if conv_start is None:
+        return "            "
+
+    ts = ts - conv_start
+    lbfc_c = int((ts)//90)
+    lbfc_o = ts-lbfc_c*90
+
+    # guard + simplex + guard + 4* uplink + 4* downlink
+    # 1 + 20.32 + 1.24 + 4 * (8.28 + 0.22) + 0.02 + 4 * (8.28 + 0.1) - 0.1
+
+    # moved the first guard from the begining to the end
+    slots = (20.32+1.24,
+             8.28+0.22, 8.28+0.22, 8.28+0.22, 8.28+0.22+0.02,
+             8.28+0.1,  8.28+0.1,  8.28+0.1,  8.28+1 + early_frame, )
+
+    sname = ("S", "U1", "U2", "U3", "U4", "D1", "D2", "D3", "D4", )
+
+    st = 0
+    for i, t in enumerate(slots):
+        if lbfc_o < st + t - early_frame: # allow slots to start slightly early
+            if len(sname[i]) == 1:
+                slot = f"{sname[i]}{round(lbfc_o - st):+03d}"
+            else:
+                slot = f"{sname[i]}{round(lbfc_o - st):+2d}"
+            break
+        st += t
+    return f"{lbfc_c:03d}∆{lbfc_o:+03.0f}#{slot}"
 
 
 class ReassembleTIME(Reassemble):
@@ -17,17 +58,24 @@ class ReassembleTIME(Reassemble):
 
     def filter(self, line):
         q = super().filter(line)
-        if q is None: return None
+        if q is None:
+            print("-", line, end="")
+            return None
         return q
 
     def process(self, q):
         q.enrich(channelize=True)
-        if self.toff is None:
+        if self.toff is None and q.typ in ("IRA:", "ITL:", "INP:", "IMS:", "MSG:"):
             self.toff = q.mstime
-        strtime = dt.epoch(q.time).isoformat(timespec='centiseconds')
-        lbfc_c = (q.mstime-self.toff+45)//90
-        lbfc_o = q.mstime-self.toff-lbfc_c*90
-        return [f"{strtime} {lbfc_c%48:02.0f}#{lbfc_o:+07.3f} {q.typ} {q.freq_print} {q.confidence:3d}% {q.level:6.2f} {q.symbols} {q.uldl} {q.data}"]
+        q.uxtime = np.datetime64(int(q.starttime), 's')
+        q.uxtime += np.timedelta64(q.nstime, 'ns')
+        strtime = str(q.uxtime)[:-2]
+        if False:
+            lbfc_c = (q.mstime-self.toff+45)//90
+            lbfc_o = q.mstime-self.toff-lbfc_c*90
+            return [f"{strtime} {lbfc_c%48:02.0f}#{lbfc_o:+07.3f} {q.typ} {q.freq_print} {q.confidence:3d}% {q.level:6.2f} {q.symbols} {q.uldl} {q.data}"]
+        lbs = lbfc_str(q.mstime, self.toff)
+        return [f"{strtime} {lbs} {q.typ} {q.freq_print} {q.confidence:3d}% {q.level:6.2f} {q.symbols} {q.uldl} {q.data}"]
 
     def consume(self, q):
         print(q, end="", file=outfile)

--- a/itl.py
+++ b/itl.py
@@ -707,8 +707,8 @@ def map_sat(num, version):
             return ("S%02d"%(num-84), "N%02d"%(2))
         elif num >=96 and num <=107:
             return ("R%02d"%(((num-96)%3)+1), "N%02d"%(((num-96)//3)+3))
-        elif num == 108:
-            return ("---", "SSS")
+        elif num >= 108 and num <= 109:
+            return ("---", "SS%d"%(num-108))
         elif num == 111:
             return ("---", "N%02d"%(8))
         else:

--- a/stats.py
+++ b/stats.py
@@ -45,6 +45,8 @@ frames['VOD'] = [colors[ 1], 'x', 1]
 frames['VDA'] = [colors[ 2], 'o', 1]
 frames['VO6'] = [colors[12], 'o', 1]
 
+frames['INP'] = [colors[ 5], 'x', 1]
+
 frames['IRI'] = ['purple',   'x', 0]
 frames['RAW'] = ['grey',     'x', 0]
 frames['NC1'] = ['grey',     'x', 0]


### PR DESCRIPTION
## what's here

this is based on experimental-new-pkt branch and adds two things:

- merge of NP/INP detector and reassembler (unchanged)
- two small classifier patches for Certus traffic bursts (IC1/IC2/IC8)

nothing that touches existing decode paths for Block1 frames. all new detectors are gated by burst length and the `self.next` flag, so they don't steal IRA/VOC/etc.

## changes

- `bitsparser.py` - new `IC1:`, `IC2:`, `IC8:` frame tags recognised by payload symbol count (200 / 432 / 1824) on Certus UW
- `bitsparser.py` - guard against misclassifying `iridium_access` DL frames as `IC1/IC2/IC8` (was a false-positive source)
- picks up NP/INP detector (`np_crc8` poly 0x12F, `np_crc16` poly 0x1755B, magic_checksum + reassembler) as merged

## what INP looks like on-air

based on captures + patent US9733338B1 (Iridium Communications, 2017, "single satellite geolocation systems and methods") this is almost certainly passive-geolocation broadcasts:

- 100% simplex DL, 1626.40 - 1626.52 MHz
- 96-bit header (empirically mapped - sync/type word, variant byte, 14-bit source id printed as `:%05d`, CRC8 on bits 80-87, tail flags)
- body high-entropy, scrambled from bit 0
- the known magic_checksum + CRC16 catches them cleanly without needing any FEC

we can't recover the body contents - descrambling looks to live in PHY silicon rather than anywhere we can touch statically.

## Certus IC1/IC2/IC8

payload symbol counts consistent with public Certus documentation:

- IC1 - 200 symbols, QPSK rate 4/5
- IC2 - 432 symbols, QPSK rate 2/3
- IC8 - 1824 symbols, 16APSK rate 2/3

content is Turbo-FEC + scrambled, body opaque here. the tags just let you slice out these bursts for further work.

## stats

parsed two multi-hour captures from two separate sites with `--uw-ec --harder`:

- site A: 790,764 frames, INP = 2,162 (100% simplex DL)
- site B: 25,507,924 frames, INP = 33,438 (100% simplex DL), plus ~7M Certus NXT traffic

cross-site consistency on INP header bits is good - same sync/variant/source-id structure, additional 96-bit header variants seen at site B (more beams in view).

## open questions / wip

- IC8 being 16APSK: consistent with symbol count + rate, but we don't decode modulation directly yet
- INP body descrambling: out of scope, treat body bits as opaque
- a `H:2` INP header sub-family (hdr_id == 0110 vs 1000/0111) found in site B captures - handled by the existing NP class, just a different sub-population visible at some locations

## testing

- ran the merged branch against existing master captures - no regressions on known frame types
- INP detection is additive, only claims frames that the magic_checksum + CRC16 accept
- IC1/IC2/IC8 classification has the `self.next` guard so it can't steal iridium_access bursts
